### PR TITLE
fix: handle case where momento auth token is not stored as single string

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -28,6 +28,8 @@ Below is a list of optional environment variables you can pass in:
 * `AUTO_ROTATION_IN_DAYS`: override the schedule (in days) in which the signing key will be renewed. **Default:** 11 days
 * `EXPORT_METRICS`: set to `true` if you would like the lambda to publish CloudWatch metrics to your account indicating the time until the signing key expires. **Default:** `false`
 * `KMS_KEY_ARN`: override if you want to use your own KMS key to encrypt your secret in Secrets Manager. **Default:** `null`
+* `AUTH_TOKEN_KEY_VALUE`: override if you are not storing your Momento auth token as a regular string in Secrets Manager. Example: if you are storing your auth token like this: `{"token": "<momento token value>"}`,
+   you would pass in `token`.
 
 ## To tear down stack
 ```shell

--- a/infrastructure/bin/infrastructure.ts
+++ b/infrastructure/bin/infrastructure.ts
@@ -13,6 +13,7 @@ const autoRotationInDays: string =
 const exportMetrics: boolean =
   process.env.EXPORT_METRICS?.toLowerCase() === 'true' ? true : false ?? false;
 const kmsKeyArn: string | undefined = process.env.KMS_KEY_ARN;
+const authTokenKeyValue: string | undefined = process.env.AUTH_TOKEN_KEY_VALUE;
 
 const app = new cdk.App();
 new InfrastructureStack(app, 'momento-signing-key-renewal-stack', {
@@ -21,4 +22,5 @@ new InfrastructureStack(app, 'momento-signing-key-renewal-stack', {
   signingKeyTtlMinutes: parseInt(singingKeyTtlMinutes),
   rotateAutomaticallyAfterInDays: parseInt(autoRotationInDays),
   kmsKeyArn: kmsKeyArn,
+  authTokenKeyValue: authTokenKeyValue,
 });

--- a/infrastructure/lib/infrastructure-stack.ts
+++ b/infrastructure/lib/infrastructure-stack.ts
@@ -24,6 +24,10 @@ interface Props extends cdk.StackProps {
   rotateAutomaticallyAfterInDays: number;
   // Override this if you are not using the default AWS KMS key for your secret
   kmsKeyArn?: string;
+  // Override this if you are not storing your Momento auth token as a simple string.
+  // Example: if this it is persisted in SecretsManager as '{"token": "<momento auth token value>"}', you
+  // would pass in "token"
+  authTokenKeyValue?: string;
 }
 
 export class InfrastructureStack extends cdk.Stack {
@@ -145,6 +149,9 @@ export class InfrastructureStack extends cdk.Stack {
         },
       }
     );
+    if (props.authTokenKeyValue) {
+      func.addEnvironment('AUTH_TOKEN_KEY_VALUE', props.authTokenKeyValue);
+    }
 
     func.grantInvoke(new iam.ServicePrincipal('secretsmanager.amazonaws.com'));
 


### PR DESCRIPTION
This PR is intended mostly for Momento internal workings, but also allows
customers to use secrets that were stored with a default key-value structure for
their Momento auth token.

Noticed that a non-default secret I gave was causing the signing key to fail to
rotate, so this fixes that case
