### PR TITLE
fix: separate cdk stack props from business logic config, fix stack props

### DIFF
--- a/infrastructure/bin/infrastructure.ts
+++ b/infrastructure/bin/infrastructure.ts
@@ -19,15 +19,17 @@ const useDockerImageLambda: boolean =
 
 const app = new cdk.App();
 new InfrastructureStack(app, 'momento-signing-key-renewal-stack', {
-  env: {
-    account: process.env.OVERRIDE_ACCOUNT_ID || process.env.CDK_DEFAULT_ACCOUNT,
-    region: process.env.OVERRIDE_REGION || process.env.CDK_DEFAULT_REGION,
+    env: {
+      account: process.env.OVERRIDE_ACCOUNT_ID || process.env.CDK_DEFAULT_ACCOUNT,
+      region: process.env.OVERRIDE_REGION || process.env.CDK_DEFAULT_REGION,
+    },
   },
-  momentoSigningKeySecretName: momentoSigningKeySecretName,
-  exportMetrics: exportMetrics,
-  signingKeyTtlMinutes: parseInt(singingKeyTtlMinutes),
-  rotateAutomaticallyAfterInDays: parseInt(autoRotationInDays),
-  kmsKeyArn: kmsKeyArn,
-  authTokenKeyValue: authTokenKeyValue,
-  useDockerImageLambda: useDockerImageLambda,
-});
+  {
+    momentoSigningKeySecretName: momentoSigningKeySecretName,
+    exportMetrics: exportMetrics,
+    signingKeyTtlMinutes: parseInt(singingKeyTtlMinutes),
+    rotateAutomaticallyAfterInDays: parseInt(autoRotationInDays),
+    kmsKeyArn: kmsKeyArn,
+    authTokenKeyValue: authTokenKeyValue,
+    useDockerImageLambda: useDockerImageLambda,
+  });

--- a/infrastructure/bin/infrastructure.ts
+++ b/infrastructure/bin/infrastructure.ts
@@ -18,9 +18,13 @@ const useDockerImageLambda: boolean =
   process.env.USE_DOCKER_IMAGE_LAMBDA?.toLowerCase() === 'true' ?? false;
 
 const app = new cdk.App();
-new InfrastructureStack(app, 'momento-signing-key-renewal-stack', {
+new InfrastructureStack(
+  app,
+  'momento-signing-key-renewal-stack',
+  {
     env: {
-      account: process.env.OVERRIDE_ACCOUNT_ID || process.env.CDK_DEFAULT_ACCOUNT,
+      account:
+        process.env.OVERRIDE_ACCOUNT_ID || process.env.CDK_DEFAULT_ACCOUNT,
       region: process.env.OVERRIDE_REGION || process.env.CDK_DEFAULT_REGION,
     },
   },
@@ -32,4 +36,5 @@ new InfrastructureStack(app, 'momento-signing-key-renewal-stack', {
     kmsKeyArn: kmsKeyArn,
     authTokenKeyValue: authTokenKeyValue,
     useDockerImageLambda: useDockerImageLambda,
-  });
+  }
+);

--- a/infrastructure/lib/infrastructure-stack.ts
+++ b/infrastructure/lib/infrastructure-stack.ts
@@ -35,7 +35,12 @@ interface SigningKeyOptions {
 }
 
 export class InfrastructureStack extends cdk.Stack {
-  constructor(scope: Construct, id: string, stackProps: cdk.StackProps, signingKeyOptions: SigningKeyOptions) {
+  constructor(
+    scope: Construct,
+    id: string,
+    stackProps: cdk.StackProps,
+    signingKeyOptions: SigningKeyOptions
+  ) {
     super(scope, id, stackProps);
 
     // Having a CfnParameter here should ensure that one-click deploy users can pass in their Secret ARN containing
@@ -152,7 +157,8 @@ export class InfrastructureStack extends cdk.Stack {
             MOMENTO_AUTH_TOKEN_SECRET_ARN:
               momentoAuthTokenSecretArnParam.valueAsString,
             EXPORT_METRICS: signingKeyOptions.exportMetrics.toString(),
-            SIGNING_KEY_TTL_MINUTES: signingKeyOptions.signingKeyTtlMinutes.toString(),
+            SIGNING_KEY_TTL_MINUTES:
+              signingKeyOptions.signingKeyTtlMinutes.toString(),
           },
         }
       );
@@ -171,19 +177,25 @@ export class InfrastructureStack extends cdk.Stack {
           MOMENTO_AUTH_TOKEN_SECRET_ARN:
             momentoAuthTokenSecretArnParam.valueAsString,
           EXPORT_METRICS: signingKeyOptions.exportMetrics.toString(),
-          SIGNING_KEY_TTL_MINUTES: signingKeyOptions.signingKeyTtlMinutes.toString(),
+          SIGNING_KEY_TTL_MINUTES:
+            signingKeyOptions.signingKeyTtlMinutes.toString(),
         },
       });
     }
     if (signingKeyOptions.authTokenKeyValue) {
-      func.addEnvironment('AUTH_TOKEN_KEY_VALUE', signingKeyOptions.authTokenKeyValue);
+      func.addEnvironment(
+        'AUTH_TOKEN_KEY_VALUE',
+        signingKeyOptions.authTokenKeyValue
+      );
     }
 
     func.grantInvoke(new iam.ServicePrincipal('secretsmanager.amazonaws.com'));
 
     momentoSigningKeySecret.addRotationSchedule('rotation-schedule', {
       rotationLambda: func,
-      automaticallyAfter: Duration.days(signingKeyOptions.rotateAutomaticallyAfterInDays),
+      automaticallyAfter: Duration.days(
+        signingKeyOptions.rotateAutomaticallyAfterInDays
+      ),
     });
   }
 

--- a/infrastructure/lib/infrastructure-stack.ts
+++ b/infrastructure/lib/infrastructure-stack.ts
@@ -13,7 +13,7 @@ import {
   ServicePrincipal,
 } from 'aws-cdk-lib/aws-iam';
 
-interface Props extends cdk.StackProps {
+interface SigningKeyOptions {
   // The name you would like to give to the Secret containing your Momento signing key
   momentoSigningKeySecretName?: string;
   // Set to true if you would like metrics exported to your AWS account
@@ -35,8 +35,8 @@ interface Props extends cdk.StackProps {
 }
 
 export class InfrastructureStack extends cdk.Stack {
-  constructor(scope: Construct, id: string, props: Props) {
-    super(scope, id);
+  constructor(scope: Construct, id: string, stackProps: cdk.StackProps, signingKeyOptions: SigningKeyOptions) {
+    super(scope, id, stackProps);
 
     // Having a CfnParameter here should ensure that one-click deploy users can pass in their Secret ARN containing
     // their Momento auth token
@@ -51,12 +51,12 @@ export class InfrastructureStack extends cdk.Stack {
     );
 
     InfrastructureStack.validateRotationParams(
-      props.signingKeyTtlMinutes,
-      props.rotateAutomaticallyAfterInDays
+      signingKeyOptions.signingKeyTtlMinutes,
+      signingKeyOptions.rotateAutomaticallyAfterInDays
     );
 
-    const signingKeyName = props.momentoSigningKeySecretName
-      ? props.momentoSigningKeySecretName
+    const signingKeyName = signingKeyOptions.momentoSigningKeySecretName
+      ? signingKeyOptions.momentoSigningKeySecretName
       : 'momento/signing-key';
     let momentoSigningKeySecret: secretsmanager.Secret;
 
@@ -74,12 +74,12 @@ export class InfrastructureStack extends cdk.Stack {
         ],
       }
     );
-    if (props.kmsKeyArn !== undefined) {
+    if (signingKeyOptions.kmsKeyArn !== undefined) {
       lambdaRole.addToPolicy(
         new PolicyStatement({
           effect: Effect.ALLOW,
           actions: ['kms:Decrypt', 'kms:GenerateDataKey'],
-          resources: [props.kmsKeyArn],
+          resources: [signingKeyOptions.kmsKeyArn],
         })
       );
       momentoSigningKeySecret = new secretsmanager.Secret(
@@ -90,7 +90,7 @@ export class InfrastructureStack extends cdk.Stack {
           encryptionKey: kms.Key.fromKeyArn(
             this,
             'secret-kms-key',
-            props.kmsKeyArn
+            signingKeyOptions.kmsKeyArn
           ),
         }
       );
@@ -138,7 +138,7 @@ export class InfrastructureStack extends cdk.Stack {
     );
 
     let func: lambda.Function;
-    if (props.useDockerImageLambda) {
+    if (signingKeyOptions.useDockerImageLambda) {
       func = new lambda.DockerImageFunction(
         this,
         'momento-signing-key-renewal-lambda-docker',
@@ -151,8 +151,8 @@ export class InfrastructureStack extends cdk.Stack {
           environment: {
             MOMENTO_AUTH_TOKEN_SECRET_ARN:
               momentoAuthTokenSecretArnParam.valueAsString,
-            EXPORT_METRICS: props.exportMetrics.toString(),
-            SIGNING_KEY_TTL_MINUTES: props.signingKeyTtlMinutes.toString(),
+            EXPORT_METRICS: signingKeyOptions.exportMetrics.toString(),
+            SIGNING_KEY_TTL_MINUTES: signingKeyOptions.signingKeyTtlMinutes.toString(),
           },
         }
       );
@@ -170,20 +170,20 @@ export class InfrastructureStack extends cdk.Stack {
         environment: {
           MOMENTO_AUTH_TOKEN_SECRET_ARN:
             momentoAuthTokenSecretArnParam.valueAsString,
-          EXPORT_METRICS: props.exportMetrics.toString(),
-          SIGNING_KEY_TTL_MINUTES: props.signingKeyTtlMinutes.toString(),
+          EXPORT_METRICS: signingKeyOptions.exportMetrics.toString(),
+          SIGNING_KEY_TTL_MINUTES: signingKeyOptions.signingKeyTtlMinutes.toString(),
         },
       });
     }
-    if (props.authTokenKeyValue) {
-      func.addEnvironment('AUTH_TOKEN_KEY_VALUE', props.authTokenKeyValue);
+    if (signingKeyOptions.authTokenKeyValue) {
+      func.addEnvironment('AUTH_TOKEN_KEY_VALUE', signingKeyOptions.authTokenKeyValue);
     }
 
     func.grantInvoke(new iam.ServicePrincipal('secretsmanager.amazonaws.com'));
 
     momentoSigningKeySecret.addRotationSchedule('rotation-schedule', {
       rotationLambda: func,
-      automaticallyAfter: Duration.days(props.rotateAutomaticallyAfterInDays),
+      automaticallyAfter: Duration.days(signingKeyOptions.rotateAutomaticallyAfterInDays),
     });
   }
 


### PR DESCRIPTION
This commit fixes an issue where the cdk StackProps were not being
consumed at all.  They were passed to our stack constructor but not
through to the superclass constructor.

To make the constructor arguments more clear, we should not be
extending cdk.StackProps; we should retain separate constructor
args for StackProps vs. the options that are related to our business
logic.  This commit also addresses that issue by removing the
inheritance and splitting out a separate constructor arg for the
business logic config.
